### PR TITLE
latex output: escape headers

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -179,7 +179,7 @@ function latex_char_escape(char::SubString)
     end
 end
 
-function latex_escape(cell::String)
+function latex_escape(cell::AbstractString)
     cell = replace(cell, ['\\','~','#','$','%','&','_','^','{','}'], latex_char_escape)
     return cell
 end
@@ -195,7 +195,7 @@ function Base.writemime(io::IO,
     write(io, alignment)
     write(io, "}\n")
     write(io, "\t& ")
-    header = join(cnames, " & ")
+    header = join(map(c -> latex_escape(string(c)), cnames), " & ")
     write(io, header)
     write(io, "\\\\ \n")
     write(io, "\t\\hline \n")


### PR DESCRIPTION
We need to escape the headers as well as the cells.

```
d = DataFrame(A_B=1:3)
d[symbol("α ` \" ' & foo \$ \\")] = "ö & ? \$ ` \\"
d[:±] = DataFrame(λ=1:3)
d
```
